### PR TITLE
Update test_public_extra.py

### DIFF
--- a/test_public_extra.py
+++ b/test_public_extra.py
@@ -146,9 +146,9 @@ class TestEhIntersecaoValida:
         t = tuple(tuple(1 for _ in range(99)) for _ in range(26))
         assert fp.eh_intersecao_valida(t, ('Z', 99))
 
-    def test_7(self):
-        t = tuple(tuple(1 for _ in range(100)) for _ in range(26))
-        assert not fp.eh_intersecao_valida(t, ('Z', 100))
+    #def test_7(self):
+    #    t = tuple(tuple(1 for _ in range(100)) for _ in range(26))
+    #    assert not fp.eh_intersecao_valida(t, ('Z', 100))
 
 class TestEhIntersecaoLivre:
 


### PR DESCRIPTION
Teste invalido, pois no PDF pede para assumirmos que quando não for pedido para validar algo, não é necessário.

aqui estamos a testar com valores fora do que é esperado. fazendo com que o teste seja invalido por essa mesma assunção.